### PR TITLE
Modify the code to capture the upper 4 bits of the *FX 151,230 and us…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ tools/vasm/obj/
 tools/vasm/vasmvidcore_std
 tools/vasm/vobjdump
 not_in_git/
+.cproject
+.project
+.settings/language.settings.xml

--- a/src/NS32016/mem32016.c
+++ b/src/NS32016/mem32016.c
@@ -34,6 +34,10 @@
 
 uint8_t ns32016ram[MEG16];
 
+#ifndef RAM_SIZE
+static uint32_t RAM_SIZE = MEG1;
+#endif
+
 void init_ram(void)
 {
 #ifdef TEST_SUITE
@@ -47,6 +51,22 @@ void init_ram(void)
    for (Address = 0; Address < MEG16; Address += sizeof(PandoraV2_00))
    {
       memcpy(ns32016ram + Address, PandoraV2_00, sizeof(PandoraV2_00));
+   }
+#endif
+
+#ifndef RAM_SIZE
+   switch ((co_options >> 4) & 0x0F)
+   {
+      default:
+      case 0: RAM_SIZE = MEG1; break;
+      case 1: RAM_SIZE = K128; break;
+      case 2: RAM_SIZE = K256; break;
+      case 3: RAM_SIZE = K512; break;
+      case 4: RAM_SIZE = K640; break;
+      case 5: RAM_SIZE = MEG2; break;
+      case 6: RAM_SIZE = MEG4; break;
+      case 7: RAM_SIZE = MEG8; break;
+      case 8: RAM_SIZE = MEG15; break;
    }
 #endif
 }

--- a/src/NS32016/mem32016.h
+++ b/src/NS32016/mem32016.h
@@ -1,7 +1,7 @@
 #define IO_BASE         0xFFFFF0
 
 //#define PANDORA_BASE    0xF00000
-#define RAM_SIZE        MEG1
+//#define RAM_SIZE        MEG1
 
 //#define TEST_SUITE
 #ifdef TEST_SUITE

--- a/src/tube-client.c
+++ b/src/tube-client.c
@@ -83,7 +83,7 @@ static const func_ptr emulator_functions[] = {
 
 #endif
 
-volatile int copro;
+volatile int copro, co_options;
 
 static func_ptr emulator;
 

--- a/src/tube-ula.c
+++ b/src/tube-ula.c
@@ -234,7 +234,8 @@ static void tube_host_read(uint16_t addr)
 static void tube_host_write(uint16_t addr, uint8_t val)
 {
    if ((addr & 7) == 6) {
-      copro = val;
+      copro = val & 0x0F;
+      co_options = val;
       return;
    }
    if (!tube_enabled) {

--- a/src/tube.h
+++ b/src/tube.h
@@ -5,7 +5,7 @@
 
 #include <inttypes.h>
 
-extern volatile int copro;
+extern volatile int copro, co_options;
 
 extern volatile uint32_t *tube_mailbox;
 


### PR DESCRIPTION
…e them as options for CoPro's

Use the upper 4 bits on the 32016 to select the RAM size
Uncomment the #define RAM_SIZE to revert to a Hard Coded RAM Size