### PR TITLE
Coprocessor lists show configured 6502 speeds

### DIFF
--- a/src/copro-defs.c
+++ b/src/copro-defs.c
@@ -58,7 +58,7 @@ copro_def_t copro_defs[] = {
       NO_DEBUGGER
    },
    {
-      "65C02 (3MHz)",           // 1
+      "65C02",                  // 1
       copro_65tube_emulator,
       TYPE_65TUBE_1,
       NO_DEBUGGER
@@ -70,7 +70,7 @@ copro_def_t copro_defs[] = {
       NO_DEBUGGER
    },
    {
-      "65C102 (4MHz)",          // 3
+      "65C102",                 // 3
       copro_65tube_emulator,
       TYPE_65TUBE_3,
       NO_DEBUGGER

--- a/src/programs.c
+++ b/src/programs.c
@@ -2733,7 +2733,6 @@ unsigned char dormann_d65c02[] = {
 #endif
 
 void copy_test_programs(uint8_t *memory) {
-
    memcpy(memory + 0x800, sphere, sizeof(sphere));
 
    strcpy((char *)memory + 0x805,        " PiTubeDirect "RELEASENAME);
@@ -2749,20 +2748,28 @@ void copy_test_programs(uint8_t *memory) {
    unsigned char *list_end = memory + 0x2000 + sizeof(coprolist);
    int list_remain = 480;   // write max 480 chars, +1 for \0
    for (int i = 0; i < num_copros(); i++) {
-
       copro_def_t *copro_def = &copro_defs[i];
 
       if (copro_def->type == TYPE_HIDDEN) {
          continue;
       }
 
-      int reqd = snprintf((char *) list_end, list_remain, "%2d %s\r", i, copro_def->name);
+      // write the name of the processor to the output buffer
+      int reqd =
+         (i == 1 || i == 3)?
+            snprintf((char *) list_end, list_remain, "%2d %s (%uMHz)\r",
+                     i, copro_def->name, get_copro_mhz(i)):
+            snprintf((char *) list_end, list_remain, "%2d %s\r",
+                     i, copro_def->name);
 
-      // if we had space for the complete line move on, else scrap it
-      if (reqd < list_remain) {
-         list_end += reqd;
-         list_remain -= reqd;
+      // if we didn't have space for this line, stop here
+      if (reqd >= list_remain) {
+         break;
       }
+
+      // move the pointers for the next line / remaining space
+      list_end += reqd;
+      list_remain -= reqd;
    }
    *list_end = '\0';   // end of text marker
 

--- a/src/tube-client.c
+++ b/src/tube-client.c
@@ -156,25 +156,30 @@ static unsigned int get_copro_number() {
    return copro;
 }
 
-static void get_copro_speed() {
+unsigned int get_copro_mhz(int copro_num) {
+   unsigned int copro_mhz = 0; // default
    char *copro_prop = NULL;
-   copro_speed = 0; // default
    // Note: Co Pro Speed is only implemented in the 65tube Co Processors (copros 0/1/2/3)
-   if (copro_def->type == TYPE_65TUBE_1) {
-      copro_speed = 3; // default to 3MHz (65C02)
+   if (copro_defs[copro_num].type == TYPE_65TUBE_1) {
+      copro_mhz = 3; // default to 3MHz (65C02)
       copro_prop = get_cmdline_prop("copro1_speed");
-   } else if (copro_def->type == TYPE_65TUBE_3) {
-      copro_speed = 4; // default to 4MHz (65C102)
+   } else if (copro_defs[copro_num].type == TYPE_65TUBE_3) {
+      copro_mhz = 4; // default to 4MHz (65C102)
       copro_prop = get_cmdline_prop("copro3_speed");
    }
    if (copro_prop) {
-      copro_speed = atoi(copro_prop);
+      copro_mhz = atoi(copro_prop);
    }
-   if (copro_speed > 255) {
-      copro_speed = 0;
+   if (copro_mhz > 255) {
+      copro_mhz = 0;
    }
+   return copro_mhz;
+}
+
+static void get_copro_speed() {
+   copro_speed = get_copro_mhz(copro);
    LOG_DEBUG("emulator speed %u\r\n", copro_speed);
-   if (copro_speed !=0 ) {
+   if (copro_speed !=0) {
       copro_speed = (arm_speed / (1000000 / 256) / copro_speed);
    }
 }

--- a/src/tube-client.h
+++ b/src/tube-client.h
@@ -5,6 +5,7 @@
 
 
 unsigned char * copro_mem_reset(int length);
+unsigned int get_copro_mhz(int copro_num);
 
 
 #endif

--- a/src/tube-commands.c
+++ b/src/tube-commands.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include "swi.h"
 #include "tube-swi.h"
+#include "tube-client.h"
 #include "tube-commands.h"
 #include "darm/darm.h"
 #include "tube-defs.h"
@@ -116,6 +117,7 @@ int doCmdTest(const char *params) {
 }
 
 int doCmdHelp(const char *params) {
+  char buff[10];
   if (*params == 0x00 || *params == 0x0a || *params == 0x0d) {
     // *HELP without any parameters
     OS_Write0(help);
@@ -162,6 +164,11 @@ int doCmdHelp(const char *params) {
         OS_WriteC('0' + i % 10);
         OS_WriteC(' ');
         OS_Write0(copro_def->name);
+        if (i == 1 || i == 3) {
+          if (snprintf(buff, 10, " (%uMHz)", get_copro_mhz(i)) < 10) {
+            OS_Write0(buff);
+          }
+        }
         OS_Write0("\r\n");
      }
   }


### PR DESCRIPTION
Rather than just displaying 3 and 4MHz, for copros 1 and 3,
respectively, they now show the speed configured in cmdline.txt.