### PR TITLE
Fix compilation of 65816.c

### DIFF
--- a/src/65816/65816.c
+++ b/src/65816/65816.c
@@ -5,6 +5,7 @@
   Originally from Snem, with some bugfixes*/
 
 #include <stdio.h>
+#include <stdint.h>
 #include "65816.h"
 
 #include "../tube-ula.h"


### PR DESCRIPTION
Fix the following issue:

In file included from PiTubeDirect/src/65816/65816.c:8:
PiTubeDirect/src/65816/65816.h:23:1: error: unknown type name 'uint8_t'
   23 | uint8_t *w65816_init(void *rom, uint32_t nativeVectBank);
      | ^~~~~~~
PiTubeDirect/src/65816/65816.h:1:1: note: 'uint8_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
  +++ |+#include <stdint.h>
    1 | #ifndef __INC_65816_H
PiTubeDirect/src/65816/65816.h:23:33: error: unknown type name 'uint32_t'
   23 | uint8_t *w65816_init(void *rom, uint32_t nativeVectBank);
      |                                 ^~~~~~~~
PiTubeDirect/src/65816/65816.h:23:33: note: 'uint32_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
